### PR TITLE
Bump the version to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii-canvas"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 description = "simple canvas for drawing lines and styled text and emitting to the terminal"
 repository = "https://github.com/nikomatsakis/ascii-canvas"


### PR DESCRIPTION
term is present in the public API and updating it means that we
should've bumped the major version of this. 1.0.1 should als be yanked
as it breaks lalrpop