### PR TITLE
Bump term to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 edition = "2018"
 
 [dependencies]
-term = "0.6"
+term = "0.7"
 
 [dev-dependencies]
 diff = "0.1"


### PR DESCRIPTION
This also transitively updates to depend on dirs-next, which is a maintained replacement for the dirs crate.

Also, I noticed that 2.1.0 was never released, though it was committed a year ago.