### PR TITLE
Bump term dependency to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0/MIT"
 edition = "2018"
 
 [dependencies]
-term = "0.7"
+term = "1"
 
 [dev-dependencies]
 diff = "0.1"


### PR DESCRIPTION
This new version has some bugfixes and improvements, and greatly reduces the transitive dependencies.

Dropping the term dependency entirely
(https://github.com/lalrpop/ascii-canvas/pull/7) is still something we should do, but this is an easy improvement in the meantime.