### PR TITLE
Release version 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 description = "simple canvas for drawing lines and styled text and emitting to the terminal"
 repository = "https://github.com/lalrpop/ascii-canvas"


### PR DESCRIPTION
\#8 is breaking since we return `term::Result` in public functions