### PR TITLE
Drop cargo update handling from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,19 +19,11 @@ jobs:
           - "1.70"
           - stable
           - nightly
-        cargo-update:
-          - true
-        include:
-          - rust: stable
-            cargo-update: false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Update
-        if: matrix.cargo-update
-        run: cargo update
       - name: Build
         run: cargo build
       - name: Test


### PR DESCRIPTION
This makes sense in lalrpop, where we ship a Cargo.lock, but also a library, but here with only a library and no shipped Cargo.lock, our testing will just end up with the latest semver compatible dependency versions regardless of whether we run cargo update first or not.