### PR TITLE
Specify multiple licenses with OR instead of /

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "4.0.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 description = "simple canvas for drawing lines and styled text and emitting to the terminal"
 repository = "https://github.com/lalrpop/ascii-canvas"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 edition = "2021"
 rust-version = "1.70"
 


### PR DESCRIPTION
This is correct modern usage, and "/" has been deprecated.

https://doc.rust-lang.org/cargo/reference/manifest.html#slash